### PR TITLE
Added methods to SpineDrawableBatch that make it easy to set dynamic …

### DIFF
--- a/Source/SpineDrawableBatch.cs
+++ b/Source/SpineDrawableBatch.cs
@@ -373,38 +373,6 @@ namespace FlatRedBall.Spine
                 Skeleton.SetSkin(skin);
                 AnimationState.Apply(Skeleton);
             }
-
-            // create a new dynamic skin and copy the template skin settings
-            //var dynamicSkin = new Skin();
-            //var templateSkin = Skeleton.Data.FindSkin(skinName);
-            //if (templateSkin == null)
-            //{
-            //    throw new Exception($"The skin {skinName} does not exist on this skeleton.");
-            //}
-            //dynamicSkin.CopySkin(templateSkin);
-
-            //// get the existing placeholder data
-            //var existingSlot = templateSkin.Attachments.Where(a => a.Name == placeholderName).FirstOrDefault();
-            //var existingRegion = existingSlot.Attachment as RegionAttachment;
-            //if (existingRegion == null)
-            //{
-            //    throw new Exception($"Failed to copy {placeholderName} - make sure it exists on the skin and is a texture region placeholder!");
-            //}
-
-            //// assign the atlas texture to a new slot and call Update() to make sure the UVs are recalculated
-            //var dynamicRegion = new RegionAttachment(existingRegion);
-            //var regionData = atlasSource.FindRegion(atlasTextureName);
-            //if (regionData == null)
-            //{
-            //    throw new Exception($"{atlasTextureName} was not found in the provided atlas!");
-            //}
-            //dynamicRegion.Region = regionData;
-            //dynamicRegion.UpdateRegion();
-
-            //// finally, set the attachment on our new skin and apply the skin to the skeleton
-            //dynamicSkin.SetAttachment(existingSlot.SlotIndex, placeholderName, dynamicRegion);
-            //Skeleton.SetSkin(dynamicSkin);
-            //AnimationState.Apply(Skeleton);
         }
 
         // Eventually we want to support IAnimatable interface, but for now we'll mimic it until we're ready


### PR DESCRIPTION
Apologies for a bit of noise in the diff, my editor applied some minor spacing changes.

This PR adds two methods intended to make it easy to create dynamic skins for Spine skeletons.

Skins in Spine are shared across all SpineDrawableBatch (SDB) skeletons. So, if you make a dynamic change to a skin, it will usually immediately apply to any SDB instances that are using that skin.

Skins in Spine can just affect part of a skeleton. So you could have a skin folder for weapons, head armor, body armor, etc. This makes sense for small games with few skin changes. But this forces the artist to create combinatorial skins for every possible swap that could occur in game. This is prone to human error and also requires source file changes and re-exporting for every change. In games with a variety of NPCs, clothing, etc this is a problem.

These two methods allow you to create a dynamic skin and then apply custom atlased textures to slots on that skin. The intended pattern is for the artist to create a single template skin that puts default textures in all slots and then programmatically clone and alter that skin. This allows the artist to preview their animations with a base set of textures, but then those textures to be swapped dynamically at runtime. This is [Spine's recommended pattern](https://esotericsoftware.com/spine-runtime-skins#Creating-attachments), specifically:

> To solve this, you can outfit the skeleton with template images that have enough whitespace to accommodate art for all your different attachments. Now any number of attachment images can be created from the template images, but don't need to be added to the skeleton in Spine. At runtime, the attachments for the template images can be copied, then the texture regions changed. Since every image is the same size as the corresponding template image, they attach to the bone in the same position.

I will document this in the Spine section of FlatRedBall docs upon PR approval!